### PR TITLE
Resist electron-based solutions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
-module.exports = false;
+// Only the browser has a global `window` object. This check is resistant
+// to any known trick, including a `var window = this` or `this.window = this`
+// in the global scope.
+var isBrowser = new Function(
+  "try { return this === window; } catch (e) { return false; }"
+);
 
-// Only Node.JS has a process variable that is of [[Class]] process
-try {
-  module.exports = 'object' === typeof process && Object.prototype.toString.call(process) === '[object process]'
-} catch(e) {}
+module.exports = !isBrowser();


### PR DESCRIPTION
Hi!

We run our headless client-side tests on [devtool](https://github.com/Jam3/devtool) – an *electron*-based environment which exposes *node.js* APIs. They expose node’s `global` and `process` globals, so *detect-node* wrongly reports that the code is running in node.

I’ve tested this solution in node and electron, trying to trick each of them by modifying top-level `window` and `this.window` references. It reports reliably at all times.

Credits to @tenavanetti – I found [his original solution](http://stackoverflow.com/a/31090240/2816199) on StackOverflow.