### PR TITLE
Fix License inconsistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detect-node",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Detect Node.JS (as opposite to browser environment) (reliable)",
   "main": "index.js",
   "browser": "browser.js",
@@ -16,7 +16,7 @@
     "node"
   ],
   "author": "Ilya Kantor",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/iliakan/detect-node/issues"
   },


### PR DESCRIPTION
In #9 and LICENSE it says it is licensed under MIT. However, the package.json has another identifier. This PR resolves the issue.
- Updates the package.json to fully resolve iliakan/detect-node#9
- replace ISC with MIT as stated in LICENSE and iliakan/detect-node#9