### PR TITLE
Add esm version

### DIFF
--- a/index.esm.js
+++ b/index.esm.js
@@ -1,0 +1,2 @@
+// Only Node.JS has a process variable that is of [[Class]] process
+export default Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.5",
   "description": "Detect Node.JS (as opposite to browser environment) (reliable)",
   "main": "index.js",
+  "module": "index.esm.js",
   "browser": "browser.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Unbundled development tools like Vite and Snowpack convert CommonJS to ESM before running. It makes these tools easier to use is an ESM version is available. E.g. it's currently difficult to use the `svelte-query` package with Vite because it has a transitive dependency on `detect-node`, which does not distribute an ESM version (https://github.com/SvelteStack/svelte-query/issues/22)