### PR TITLE
make export named

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ npm install --save detect-node
 ### Usage:
 
 ```js
-var isNode = require('detect-node');
+const { isNode } = require('detect-node');
 
 if (isNode) {
   console.log("Running under Node.JS");
@@ -18,11 +18,11 @@ if (isNode) {
 
 The check is performed as:
 ```js
-module.exports = false;
+module.exports.isNode = false;
 
 // Only Node.JS has a process variable that is of [[Class]] process
 try {
- module.exports = Object.prototype.toString.call(global.process) === '[object process]' 
+ module.exports.isNode = Object.prototype.toString.call(global.process) === '[object process]' 
 } catch(e) {}
 
 ```

--- a/browser.js
+++ b/browser.js
@@ -1,2 +1,2 @@
-module.exports = false;
+module.exports.isNode = false;
 

--- a/index.esm.js
+++ b/index.esm.js
@@ -1,2 +1,2 @@
 // Only Node.JS has a process variable that is of [[Class]] process
-export default Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';
+export const isNode = Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 // Only Node.JS has a process variable that is of [[Class]] process
-module.exports = Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';
+module.exports.isNode = Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';


### PR DESCRIPTION
I propose making the export named to ease interaction with code bases that use TypeScript to compile to both CommonJS and ES modules.

This is obviously a breaking change and thus requires a new major version.